### PR TITLE
Implement `DaskExecutor`

### DIFF
--- a/kedro/symphony/conductor.py
+++ b/kedro/symphony/conductor.py
@@ -54,10 +54,7 @@ class Conductor:
             assert (
                 len(executor_tags) <= 1
             )  # there should not be more than one executor tag
-            try:
-                executor_tag = next(iter(executor_tags))
-            except StopIteration:
-                executor_tag = self.default_executor
+            executor_tag = next(iter(executor_tags), self.default_executor)
 
             output[executor_tag].append(node)  # this is where nodes will go
 

--- a/kedro/symphony/executor/dask_executor.py
+++ b/kedro/symphony/executor/dask_executor.py
@@ -1,0 +1,117 @@
+# Copyright 2021 QuantumBlack Visual Analytics Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+# NONINFRINGEMENT. IN NO EVENT WILL THE LICENSOR OR OTHER CONTRIBUTORS
+# BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF, OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# The QuantumBlack Visual Analytics Limited ("QuantumBlack") name and logo
+# (either separately or in combination, "QuantumBlack Trademarks") are
+# trademarks of QuantumBlack. The License does not grant you any right or
+# license to the QuantumBlack Trademarks. You may not use the QuantumBlack
+# Trademarks or any confusingly similar mark as a trademark for your product,
+# or use the QuantumBlack Trademarks in any other manner that might cause
+# confusion in the marketplace, including but not limited to in advertising,
+# on websites, or on software.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""``DaskExecutor`` is an ``AbstractExecutor`` implementation. It can be
+used to delegate execution of the provided nodes to Dask.
+"""
+
+from contextlib import contextmanager
+from typing import Any, Iterable
+
+from distributed import Client, get_worker, wait, worker_client
+
+from kedro.io import AbstractDataSet, DataCatalog, MemoryDataSet
+from kedro.pipeline.node import Node
+from kedro.symphony.executor.executor import AbstractExecutor, run_node
+
+
+class DaskExecutor(AbstractExecutor):
+    """``DaskExecutor`` is an ``AbstractExecutor`` implementation. It
+    can be used to delegate execution of the provided nodes to Dask.
+    """
+
+    def __init__(self, nodes: Iterable[Node], is_async: bool = False):
+        """Instantiates the executor class.
+
+        Args:
+            nodes: The iterable of nodes to run.
+            is_async: If True, the node inputs and outputs are loaded and saved
+                asynchronously with threads. Defaults to False.
+
+        """
+        super().__init__(nodes, is_async=is_async)
+        self._client = Client("tcp://127.0.0.1:8786")  # TODO(deepyaman): Create client from config.
+
+    def create_default_data_set(self, ds_name: str) -> AbstractDataSet:
+        """Factory method for creating the default data set for the runner.
+
+        Args:
+            ds_name: Name of the missing data set
+
+        Returns:
+            An instance of an implementation of AbstractDataSet to be used
+            for all unregistered data sets.
+
+        """
+        return DaskDataSet(ds_name)
+
+    def _run(
+        self, nodes: Iterable[Node], catalog: DataCatalog, run_id: str = None
+    ) -> None:
+        """The method implementing sequential node running.
+
+        Args:
+            nodes: The nodes to run.
+            catalog: The ``DataCatalog`` from which to fetch data.
+            run_id: The id of the run.
+
+        Raises:
+            Exception: in case of any downstream node failure.
+        """
+        futures = [
+            self._client.submit(run_node, node, catalog, self._is_async, run_id)
+            for node in nodes
+        ]
+        wait(futures)
+
+
+@contextmanager
+def maybe_worker_client():
+    try:
+        get_worker()
+    except ValueError:
+        yield Client.current()
+    else:
+        # this is wierd - I don't understand why this is necessary
+        with worker_client(separate_thread=False) as c:
+            yield c
+
+
+class DaskDataSet(AbstractDataSet):
+    def __init__(self, name):
+        self.name = name
+
+    def _load(self) -> Any:
+        with worker_client() as c:
+            return c.get_dataset(self.name)
+
+    def _save(self, data: Any):
+        with maybe_worker_client() as c:
+            c.publish_dataset(data, name=self.name, override=True)
+
+    def _describe(self):
+        return dict(name=self.name)


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->

I tested this on the `pandas-iris` starter pipeline. The modifications I made were to:

* set `tags=["executor:kedro.symphony.executor.dask_executor.DaskExecutor"],` for the DS pipeline
* add `print("Model accuracy on test set: %0.2f%%", accuracy * 100)` to the `report_accuracy` node, because the log wasn't showing up on the worker

I started up a local Dask cluster following https://towardsdatascience.com/just-start-with-the-dask-localcluster-saturn-cloud-7dbfe5a89c9a ("What to do" section), with `export PYTHONPATH=/Users/deepyaman_datta/new-kedro-project/src` in each shell first as a quick hack (as per https://stackoverflow.com/a/39994128, where MRocklin suggests using `Client.upload_file` as a better method, which makes sense).

And then `kedro run`!

`dask-scheduler` console:

```
(kedro) WASH-178551-C02X31K9JHD4:kedro deepyaman_datta$ export PYTHONPATH=/Users/deepyaman_datta/new-kedro-project/src
(kedro) WASH-178551-C02X31K9JHD4:kedro deepyaman_datta$ dask-scheduler
distributed.scheduler - INFO - -----------------------------------------------
distributed.http.proxy - INFO - To route to workers diagnostics web server please install jupyter-server-proxy: python -m pip install jupyter-server-proxy
distributed.scheduler - INFO - -----------------------------------------------
distributed.scheduler - INFO - Clear task state
distributed.scheduler - INFO -   Scheduler at:   tcp://10.17.20.117:8786
distributed.scheduler - INFO -   dashboard at:                     :8787
distributed.scheduler - INFO - Register worker <Worker 'tcp://127.0.0.1:62838', name: tcp://127.0.0.1:62838, memory: 0, processing: 0>
distributed.scheduler - INFO - Starting worker compute stream, tcp://127.0.0.1:62838
distributed.core - INFO - Starting established connection
distributed.scheduler - INFO - Receive client connection: Client-02393ed6-37ad-11ec-adc3-acde48001122
distributed.core - INFO - Starting established connection
distributed.scheduler - INFO - Receive client connection: Client-worker-02eb9748-37ad-11ec-adba-acde48001122
distributed.core - INFO - Starting established connection
distributed.scheduler - INFO - Receive client connection: Client-02ed214e-37ad-11ec-adc3-acde48001122
distributed.core - INFO - Starting established connection
distributed.scheduler - INFO - Receive client connection: Client-02ef2c00-37ad-11ec-adc3-acde48001122
distributed.core - INFO - Starting established connection
distributed.scheduler - INFO - Remove client Client-02ef2c00-37ad-11ec-adc3-acde48001122
distributed.scheduler - INFO - Remove client Client-02ef2c00-37ad-11ec-adc3-acde48001122
distributed.scheduler - INFO - Close client connection: Client-02ef2c00-37ad-11ec-adc3-acde48001122
distributed.scheduler - INFO - Remove client Client-02ed214e-37ad-11ec-adc3-acde48001122
distributed.scheduler - INFO - Remove client Client-02393ed6-37ad-11ec-adc3-acde48001122
distributed.scheduler - INFO - Close client connection: Client-02ed214e-37ad-11ec-adc3-acde48001122
distributed.scheduler - INFO - Close client connection: Client-02393ed6-37ad-11ec-adc3-acde48001122
```

`dask-worker` console:
```
(kedro) WASH-178551-C02X31K9JHD4:kedro deepyaman_datta$ export PYTHONPATH=/Users/deepyaman_datta/new-kedro-project/src
(kedro) WASH-178551-C02X31K9JHD4:kedro deepyaman_datta$ dask-worker tcp://127.0.0.1:8786
distributed.nanny - INFO -         Start Nanny at: 'tcp://127.0.0.1:62837'
distributed.worker - INFO -       Start worker at:      tcp://127.0.0.1:62838
distributed.worker - INFO -          Listening to:      tcp://127.0.0.1:62838
distributed.worker - INFO -          dashboard at:            127.0.0.1:62839
distributed.worker - INFO - Waiting to connect to:       tcp://127.0.0.1:8786
distributed.worker - INFO - -------------------------------------------------
distributed.worker - INFO -               Threads:                          8
distributed.worker - INFO -                Memory:                   17.18 GB
distributed.worker - INFO -       Local Directory: /Users/deepyaman_datta/kedro/dask-worker-space/dask-worker-space/worker-oqend4ii
distributed.worker - INFO - -------------------------------------------------
distributed.worker - INFO -         Registered to:       tcp://127.0.0.1:8786
distributed.worker - INFO - -------------------------------------------------
distributed.core - INFO - Starting established connection
Model accuracy on test set: %0.2f%% 90.0
```

A lot of the Dask code is taken from https://github.com/hhuuggoo/kedro-dask-example/blob/416034880d9cf3500409fd49ff8053870ce6e15e/src/kedro_dask_example/io/__init__.py.

TODO:

- [ ] Test whether we can return to non-Dask workflow.

## Checklist

- [ ] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
